### PR TITLE
fix rolling window reduction error

### DIFF
--- a/loganomaly/detectors/__init__.py
+++ b/loganomaly/detectors/__init__.py
@@ -13,7 +13,16 @@ def compute_lof_scores(features, n_neighbors=20):
     Returns:
         np.ndarray: Negative LOF scores (-1 is normal, lower values more anomalous).
     """
-    lof = LocalOutlierFactor(n_neighbors=n_neighbors, contamination='auto', n_jobs=-1)
+    n_samples = features.shape[0]
+    
+    # Validate minimum samples
+    if n_samples < 2:
+        return np.zeros(n_samples), np.ones(n_samples, dtype=int)
+    
+    # Adjust n_neighbors to be at most n_samples - 1
+    adjusted_neighbors = min(n_neighbors, n_samples - 1)
+    
+    lof = LocalOutlierFactor(n_neighbors=adjusted_neighbors, contamination='auto', n_jobs=-1)
     lof_scores = lof.fit_predict(features)
     negative_factor = lof.negative_outlier_factor_
     return negative_factor, lof_scores

--- a/loganomaly/detectors/anomaly_detector.py
+++ b/loganomaly/detectors/anomaly_detector.py
@@ -32,10 +32,24 @@ def detect_knn_anomalies(df, top_percent=0.05, n_neighbors=5):
     Returns:
         pd.DataFrame: Updated DataFrame with 'anomaly_score' and 'is_anomaly'.
     """
+    n_samples = len(df)
+    
+    # Validate minimum samples
+    if n_samples < 2:
+        print(f"⚠️ Insufficient samples ({n_samples}) for KNN detection. Skipping...")
+        df["anomaly_score"] = 0.0
+        df["is_anomaly"] = 0
+        return df, None
+    
+    # Adjust n_neighbors to be at most n_samples - 1
+    adjusted_neighbors = min(n_neighbors, n_samples - 1)
+    if adjusted_neighbors < n_neighbors:
+        print(f"⚠️ Adjusted n_neighbors from {n_neighbors} to {adjusted_neighbors} (n_samples={n_samples})")
+    
     embeddings = compute_embeddings(df)
     print("📈 Calculating anomaly scores...")
 
-    knn = NearestNeighbors(n_neighbors=n_neighbors, metric="cosine", n_jobs=-1)
+    knn = NearestNeighbors(n_neighbors=adjusted_neighbors, metric="cosine", n_jobs=-1)
     knn.fit(embeddings)
     distances, _ = knn.kneighbors(embeddings)
     scores = distances.mean(axis=1)

--- a/loganomaly/processor.py
+++ b/loganomaly/processor.py
@@ -349,7 +349,7 @@ def process_file(filepath):
     df = knn_detect(df, app_config.TOP_PERCENT)
 
     if app_config.ENABLE_LOF:
-        df = detect_anomalies_lof(df, app_config.TOP_PERCENT)
+        df = detect_anomalies_lof(df, app_config.TOP_PERCENT, n_neighbors=app_config.LOF_N_NEIGHBORS)
 
     df = df.apply(apply_rule_based_classification, axis=1)
     rule_based_count = df["is_rule_based"].sum()


### PR DESCRIPTION
Summary
Fixed the ValueError: Expected n_neighbors <= n_samples_fit issue that occurred when rolling window reduction left too few samples for KNN/LOF anomaly detection.

Changes Made
1. KNN Detector (
loganomaly/detectors/anomaly_detector.py
)

Added sample count validation (minimum 2 samples required)
Dynamic adjustment of n_neighbors to min(n_neighbors, n_samples - 1)
Graceful handling when insufficient samples exist (returns zero scores)
Warning messages when adjustments are made
2. LOF Detector (
loganomaly/detectors/lof_detector.py
)

Added n_neighbors parameter to function signature
Sample count validation (minimum 2 samples)
Dynamic n_neighbors adjustment
Graceful fallback with default values when samples are insufficient
3. Processor Integration (
loganomaly/processor.py
)

Updated LOF detector call to pass app_config.LOF_N_NEIGHBORS parameter
4. Utility Function (
loganomaly/detectors/init.py
)

Fixed 
compute_lof_scores
 with same dynamic adjustment logic
Ensures test functions also handle edge cases
How It Works
When rolling window chunking reduces logs to fewer samples than the configured n_neighbors (default: 5), the detectors now:

Check if n_samples >= 2 (minimum for any neighbor-based algorithm)
Adjust n_neighbors = min(configured_value, n_samples - 1)
Display warning when adjustment occurs
Skip detection entirely if only 0-1 samples remain
This ensures the pipeline continues processing without crashes, even when log chunks are heavily reduced.